### PR TITLE
chore: update confluence index flag usage documentation

### DIFF
--- a/docs/confluence.md
+++ b/docs/confluence.md
@@ -49,7 +49,7 @@ vault-radar scan-confluence -u <INSTANCE URL> -s <SPACE KEY> -b <PATH TO BASELIN
 ### Scanning using a Vault index file
 perform a scan using a generated vault index and write the results to an outfile
 ```bash
-vault-radar scan-confluence -u <INSTANCE URL> -s <SPACE KEY> -i <PATH TO VAULT INDEX>.jsonl -o <PATH TO OUTPUT>.csv
+vault-radar scan-confluence -u <INSTANCE URL> -s <SPACE KEY> --index-file <PATH TO VAULT INDEX>.jsonl -o <PATH TO OUTPUT>.csv
 ```
 TODO - Link to generating a Vault Index
 ### Scan and restrict the number of secrets found


### PR DESCRIPTION
remove documented usage of `-i` for the index file when using the `scan-confluence` sub command