### PR TITLE
Update policy required to scan AWS Parameter Store

### DIFF
--- a/docs/aws-parameter-store.md
+++ b/docs/aws-parameter-store.md
@@ -5,7 +5,7 @@ Note that we do not scan parameters of type `SecureString` as they are secure by
 
 ## Authentication
 
-`scan-aws-parameter-store` needs permissions to read the parameter and its history, 
+`scan-aws-parameter-store` needs permissions to read the parameter, its history and tags, 
 see this simplified [policy document](./scan-aws-parameter-store-policy.json).
 Refer [AWS authentication document](./aws-authentication.md) for various ways to set up the auth.
 

--- a/docs/scan-aws-parameter-store-policy.json
+++ b/docs/scan-aws-parameter-store-policy.json
@@ -6,7 +6,9 @@
             "Action": [
                 "ssm:DescribeParameters",
                 "ssm:GetParameterHistory",
-                "ssm:GetParameter"
+                "ssm:GetParameter",
+                "ssm:GetParameters",
+                "ssm:ListTagsForResource"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
### Summary

The newer version of `vault-radar` will fetch parameter tags using SSM `ListTagsForResource` action. This action inturn requires access to `GetParameters` action to fetch tags for a parameter