### PR TITLE
Chore: Remove local file when generate key

### DIFF
--- a/aws/s3/main.tf
+++ b/aws/s3/main.tf
@@ -65,17 +65,12 @@ resource "aws_s3_object" "vault_object" {
 }
 
 // Creating a dynamic private key
-resource "tls_private_key" "ed25519-example" {
+resource "tls_private_key" "ed25519_example" {
   algorithm = "ED25519"
-}
-
-resource "local_file" "private_key" {
-  content  = tls_private_key.ed25519-example.private_key_pem
-  filename = "secret-files/example.pem"
 }
 
 resource "aws_s3_object" "private_key_object" {
   bucket = aws_s3_bucket.demo_bucket.id
   key    = "private_key"
-  source = local_file.private_key.filename
+  content = tls_private_key.ed25519_example.private_key_pem
 }


### PR DESCRIPTION
## Description

Remove the local file creation when generating a private key for AWS S3 data

## How has this been tested?

Ran terraform init and apply and confirmed new resources were created