### PR TITLE
VAULT-22103: Add docs for scan-docker-image command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,13 +9,15 @@ Currently, the only dependency of `vault-radar` is having a local installation o
 To learn more about the various commands `vault-radar` supports, follow one of the links below:
 
 * [`copy-secrets-to-vault` - Copy found secrets to vault documentation (experimental)](copy-secrets-to-vault.md)
-* [`scan-confluence` - Atlassian Confluence integration documentation](confluence.md)
-* [`scan-repo` - git integration documentation](git.md)
 * [`scan-aws-s3` - AWS S3 integration documentation](aws-s3.md)
-* [`scan-aws-parameter-store` - AWS Parameter Store integration documentation](aws-parameter-store.md)
-* [`scan-vault` - HashiCorp Vault integration documentation](vault.md)
+* [`scan-aws-parameter-store` - AWS Parameter Store integration 
+documentation](aws-parameter-store.md)
+* [`scan-confluence` - Atlassian Confluence integration documentation](confluence.md)
+* [`scan-docker-image` - Scan docker image documentation (experimental)](docker-image.md)
 * [`scan-folder` - scan-folder documentation](folder.md)
 * [`scan-file` - scan-file documentation](file.md)
+* [`scan-repo` - git integration documentation](git.md)
+* [`scan-vault` - HashiCorp Vault integration documentation](vault.md)
 
 ## Misc
 

--- a/docs/docker-image.md
+++ b/docs/docker-image.md
@@ -5,7 +5,11 @@ This `vault-radar` command is used for scanning a docker image
 
 ### Scanning a docker image
 
-Scan a public docker image (or a private image that is already pulled/dowloaded locally) and write the results to a file in CSV format, this is the default format for output. Image reference may optionally include a tag.[Docker engine](https://docs.docker.com/engine/install/) is a pre-requisite for scanning docker images using vault-radar.
+Scan a public docker image (or a private image that is already pulled/dowloaded locally) and write the results to a file in CSV format, this is the default format for output. 
+
+Image reference may optionally include a tag. We will scan the latest tag if no tag is specified.
+
+[Docker engine](https://docs.docker.com/engine/install/) is a pre-requisite for scanning docker images using vault-radar.
 
 ```bash
 vault-radar scan-docker-image -i <IMAGE REFERENCE> -o <PATH TO OUTPUT>.csv
@@ -18,7 +22,7 @@ To scan a private docker image, specify the following environment variables to a
 2. `DOCKER_REGISTRY_PASSWORD`
 
 ```bash
-vault-radar scan-docker-image -i <IMAGE REFERENCE> -f json -o <PATH TO OUTPUT>.csv
+vault-radar scan-docker-image -i <IMAGE REFERENCE> -f json -o <PATH TO OUTPUT>.json
 ```
 
 Example:

--- a/docs/docker-image.md
+++ b/docs/docker-image.md
@@ -1,0 +1,54 @@
+# `scan-docker-image` (experimental)
+This `vault-radar` command is used for scanning a docker image
+
+## Usage
+
+### Scanning a docker image
+
+Scan a public docker image (or a private image that is already pulled/dowloaded locally) and write the results to a file in CSV format, this is the default format for output. Image reference may optionally include a tag.[Docker engine](https://docs.docker.com/engine/install/) is a pre-requisite for scanning docker images using vault-radar.
+
+```bash
+vault-radar scan-docker-image -i <IMAGE REFERENCE> -o <PATH TO OUTPUT>.csv
+```
+
+### Scanning a private docker image
+
+To scan a private docker image, specify the following environment variables to authenticate against the registry:
+1. `DOCKER_REGISTRY_USERNAME`
+2. `DOCKER_REGISTRY_PASSWORD`
+
+```bash
+vault-radar scan-docker-image -i <IMAGE REFERENCE> -f json -o <PATH TO OUTPUT>.csv
+```
+
+Example:
+```bash
+export DOCKER_REGISTRY_USERNAME=<ARTIFICATORY_USERNAME>
+export DOCKER_REGISTRY_PASSWORD=<ARTIFACTORY_TOKEN>
+vault-radar scan-docker-image -i XXX.artifactory.XXX/YYY-image -f json -o results-docker-base-image.json
+```
+
+### Scanning a docker image and output in JSON
+
+Scan a docker image and write the results to a file in [JSON Lines](https://jsonlines.org/) format.  
+
+```bash
+vault-radar scan-docker-image -i <IMAGE REFERENCE> -o <PATH TO OUTPUT>.jsonl -f json
+```
+
+### Scanning using a Vault index file
+
+Perform a scan using a generated vault index and write the results to an outfile. 
+In this mode, if a risk was previously found in Vault, the scan results will report the location in Vault as well.
+
+```bash
+vault-radar scan-docker-image -p <IMAGE REFERENCE> -o <PATH TO OUTPUT>.csv --index-file <PATH TO VAULT INDEX>.jsonl
+```
+
+### Scan and restrict the number of secrets found
+
+Scan a clone and write the results to an outfile and stop scanning when the defined number of secrets are found
+
+```bash
+vault-radar scan-docker-image -p <IMAGE REFERENCE> -o <PATH TO OUTPUT>.csv -l <NUM OF SECRETS>
+```


### PR DESCRIPTION
## Description

Added a new command scan-docker-image to vault-radar CLI. This PR is to add documentation for this new command.

Resolves VAULT-22103

## How has this been tested?

Generated preview locally
