### PR TITLE
added docs to explain index generation in offline mode

### DIFF
--- a/docs/aws-parameter-store.md
+++ b/docs/aws-parameter-store.md
@@ -72,14 +72,21 @@ To stop scanning when the defined number of parameters are scanned
 vault-radar scan-aws-parameter-store -r <REGION CODE> -o <PATH TO OUTPUT>.csv --parameter-limit <NUM OF PARAMETERS>
 ```
 
-### Generate an index file of parameters of type SecureString
+### Generate an index file
+Index files are generated in an "online mode" by default, meaning that the secret hash produced is using a salt that is provided from HCP. This requires the Project Service Principals to be configured for your system as outlined by the [HCP Upload Section](hcp-upload.md). If you do not want to use the index file for HCP upload and visualization you can use the `--offline` flag to use a local hashing salt and not error if the Service Principals are not configured.
 
+```bash
+vault-radar scan-aws-parameter-store index -r <REGION CODE> -o <PATH TO OUTPUT>.jsonl --offline
+```
+
+#### Generating Parameters of type SecureString
 To generate an index file using the `SecureString` parameters
 
 ```bash
 vault-radar scan-aws-parameter-store index -r <REGION CODE> -o <PATH TO OUTPUT>.jsonl
 ```
 
+### Consuming an index file
 To consume the resulting index file use the `index-file` flag when calling a scan command. E.g.
 
 ```bash

--- a/docs/aws-parameter-store.md
+++ b/docs/aws-parameter-store.md
@@ -79,7 +79,7 @@ Index files are generated in an "online mode" by default, meaning that the secre
 vault-radar scan-aws-parameter-store index -r <REGION CODE> -o <PATH TO OUTPUT>.jsonl --offline
 ```
 
-#### Generating Parameters of type SecureString
+#### Generate index file using HCP provided salt
 To generate an index file using the `SecureString` parameters
 
 ```bash

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -81,7 +81,7 @@ vault-radar scan-confluence -outfile=confluence.csv -url="http://localhost:8090"
 An in-memory index keyed off of secret hashes will be generated prior to scanning the source. This index will be used to
 annotate whether a risk exists in Vault.
 
-### Generate an index file in offline mode
+### Generate index file using HCP provided salt
 Index files are generated in an "online mode" by default, meaning that the secret hash produced is using a salt that is provided from HCP. This requires the Project Service Principals to be configured for your system as outlined by the [HCP Upload Section](hcp-upload.md). If you do not want to use the index file for HCP upload and visualization you can use the `--offline` flag to use a local hashing salt and not error if the Service Principals are not configured.
 
 ```bash

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -75,7 +75,7 @@ The index can then be used to compare against in other scans. For example, the
 following command can be used to run a Confluence scan using a generated Vault index file:
 
 ```bash
-vault-radar scan-confluence -outfile=confluence.csv -url="http://localhost:8090" -space-key=VRD -index-file=vault.idx
+vault-radar scan-confluence --outfile=confluence.csv --url="http://localhost:8090" --space-key=VRD --index-file=vault.idx
 ```
 
 An in-memory index keyed off of secret hashes will be generated prior to scanning the source. This index will be used to
@@ -85,7 +85,7 @@ annotate whether a risk exists in Vault.
 Index files are generated in an "online mode" by default, meaning that the secret hash produced is using a salt that is provided from HCP. This requires the Project Service Principals to be configured for your system as outlined by the [HCP Upload Section](hcp-upload.md). If you do not want to use the index file for HCP upload and visualization you can use the `--offline` flag to use a local hashing salt and not error if the Service Principals are not configured.
 
 ```bash
-vault-radar scan-aws-parameter-store index -r <REGION CODE> -o <PATH TO OUTPUT>.jsonl --offline
+vault-radar scan-vault --index -r <REGION CODE> -o <PATH TO OUTPUT>.jsonl --offline
 ```
 
 ### HCP Vault considerations

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -81,6 +81,13 @@ vault-radar scan-confluence -outfile=confluence.csv -url="http://localhost:8090"
 An in-memory index keyed off of secret hashes will be generated prior to scanning the source. This index will be used to
 annotate whether a risk exists in Vault.
 
+### Generate an index file in offline mode
+Index files are generated in an "online mode" by default, meaning that the secret hash produced is using a salt that is provided from HCP. This requires the Project Service Principals to be configured for your system as outlined by the [HCP Upload Section](hcp-upload.md). If you do not want to use the index file for HCP upload and visualization you can use the `--offline` flag to use a local hashing salt and not error if the Service Principals are not configured.
+
+```bash
+vault-radar scan-aws-parameter-store index -r <REGION CODE> -o <PATH TO OUTPUT>.jsonl --offline
+```
+
 ### HCP Vault considerations
 
 In a HCP Vault cluster, the root namespace is restricted and the users will only have access to `admin` namespace and all the child namespaces within it.


### PR DESCRIPTION
## Description

Updated the docs to explain the changes to index file generation by defaulting to online mode with an explicit flag to generate for offline consumption.

## How has this been tested?

Visualized locally