### PR TITLE
mark all data sources than git/confluence as experimental

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,17 +10,17 @@ Following dependencies need to be installed on the machine `vault-radar` is runn
 ## Commands
 To learn more about the various commands `vault-radar` supports, follow one of the links below:
 
-* [`copy-secrets-to-vault` - Copy found secrets to vault documentation (experimental)](copy-secrets-to-vault.md)
-* [`scan-aws-s3` - AWS S3 integration documentation](aws-s3.md)
-* [`scan-aws-parameter-store` - AWS Parameter Store integration documentation](aws-parameter-store.md)
 * [`scan-confluence` - Atlassian Confluence integration documentation](confluence.md)
-* [`scan-docker-image` - Scan docker image documentation (experimental)](docker-image.md)
-* [`scan-folder` - scan-folder documentation](folder.md)
-* [`scan-file` - scan-file documentation](file.md)
-* [`scan-jira` - scan-jira documentation (experimantal)](jira.md)
 * [`scan-repo` - git integration documentation](git.md)
-* [`scan-tfe-variables` - TFC/TFE integration documentation](tfe-variables.md)
-* [`scan-vault` - HashiCorp Vault integration documentation](vault.md)
+* [`copy-secrets-to-vault` - Copy found secrets to vault documentation (experimental)](copy-secrets-to-vault.md)
+* [`scan-aws-s3` - AWS S3 integration documentation (experimental)](aws-s3.md)
+* [`scan-aws-parameter-store` - AWS Parameter Store integration documentation (experimental)](aws-parameter-store.md)
+* [`scan-docker-image` - Scan docker image documentation (experimental)](docker-image.md)
+* [`scan-folder` - scan-folder documentation (experimental)](folder.md)
+* [`scan-file` - scan-file documentation (experimental)](file.md)
+* [`scan-jira` - scan-jira documentation (experimental)](jira.md)
+* [`scan-tfe-variables` - TFC/TFE integration documentation (experimental)](tfe-variables.md)
+* [`scan-vault` - HashiCorp Vault integration documentation (experimental)](vault.md)
 
 ## Misc
 

--- a/docs/aws-parameter-store.md
+++ b/docs/aws-parameter-store.md
@@ -1,4 +1,4 @@
-# `scan-aws-parameter-store`
+# `scan-aws-parameter-store` (experimental)
 
 This `vault-radar` command is used for scanning parameters of type `String` and `StringList` AWS Parameter Store.
 Note: Parameters of type `SecureString` can be indexed, but will not be scanned as they are secure by definition.

--- a/docs/aws-s3.md
+++ b/docs/aws-s3.md
@@ -1,4 +1,4 @@
-# `scan-aws-s3`
+# `scan-aws-s3` (experimental)
 
 This `vault-radar` command is used for scanning an AWS S3 bucket.
 

--- a/docs/file.md
+++ b/docs/file.md
@@ -1,4 +1,4 @@
-# `scan-file`
+# `scan-file` (experimental)
 
 This `vault-radar` command is used for scanning a file. 
 It is similar to [scan-folder](folder.md) command but can scan a single file. 

--- a/docs/folder.md
+++ b/docs/folder.md
@@ -1,4 +1,4 @@
-# `scan-folder`
+# `scan-folder` (experimental)
 This `vault-radar` command is used for scanning a local folder.
 
 ## Usage

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -1,4 +1,4 @@
-# scan-vault
+# `scan-vault` (experimental)
 
 This `vault-radar` command is used for scanning a HashiCorp Vault Community Edition
 or Enterprise cluster. Scanning Vault using the `scan-vault` provides compliance reporting and secrets indexing


### PR DESCRIPTION
## Description

Address the ask from Product to mark all data sources other than git and confluence as experimental ahead of the beta release.

## How has this been tested?

Visualized locally.
