### PR TITLE
VAULT-22887: Update docs to call out support for Jira server

### DIFF
--- a/docs/jira.md
+++ b/docs/jira.md
@@ -16,6 +16,18 @@ In order to provide the information to `vault-radar`, assign the appropriate val
 1. `ATLASSIAN_API_TOKEN`
 2. `ATLASSIAN_ACCOUNT_EMAIL`
 
+### Jira Server
+For self hosted versions of Jira, there are up to 2 different patterns possible.
+
+Jira Software Version 8.14 and higher support [creating a Personal Access Token for a user](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html). The token will have all the same access rights as the user who creates it. To use the token set the following environment variable to the generated token:
+`JIRA_PERSONAL_ACCESS_TOKEN`
+
+Using a personal access token is more secure and should be the preferred access pattern. A personal access token is easier to revoke and regenerate, and generally has a smaller blast radius than a password.
+
+All versions of Jira server supports authorization using the Username (not the email), and Password. To authenticate using these credentials set both of these environment variables:
+1. `JIRA_USERNAME`
+2. `JIRA_PASSWORD`
+
 ## Usage
 The following examples all assume you have already set the appropriate environment variable or that you intend to include them as part of the command you run.
 ### Scan an issue

--- a/docs/jira.md
+++ b/docs/jira.md
@@ -19,7 +19,7 @@ In order to provide the information to `vault-radar`, assign the appropriate val
 ### Jira Server
 For self hosted versions of Jira, there are up to 2 different patterns possible.
 
-Jira Software Version 8.14 and higher support [creating a Personal Access Token for a user](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html). The token will have all the same access rights as the user who creates it. To use the token set the following environment variable to the generated token:
+Jira Software Version 8.14 and higher support [creating a Personal Access Token for a user](https://developer.atlassian.com/server/jira/platform/personal-access-token/). The token will have all the same access rights as the user who creates it. To use the token set the following environment variable to the generated token:
 `JIRA_PERSONAL_ACCESS_TOKEN`
 
 Using a personal access token is more secure and should be the preferred access pattern. A personal access token is easier to revoke and regenerate, and generally has a smaller blast radius than a password.


### PR DESCRIPTION
## Description

Update documentation to reflect support for Jira server (similar to Confluence server)

Resolves #VAULT-22887

## How has this been tested?

By generating a local preview
