### PR TITLE
VAULT-28572: SaaS Confluence | Update bootstrap script to support generating pages across all spaces

### DIFF
--- a/confluence/README.md
+++ b/confluence/README.md
@@ -47,9 +47,10 @@ http://localhost:8090/pages/viewinfo.action?pageId=12345 # 12345 is the page ID
   * you will need to set the Auth Variables, like **personalAccessToken**
   * if you are testing a different endpoint change the **confluenceInstanceURL**
   * feel free to change other variables like the number of pages to create, Space Name, Key or Description.
-* run `go run cmd/main.go` if there are errors, feel free to reach out, otherwise if it completes without any errors then your instance should be updates with additional content
+* run `go run cmd/main.go 2>&1 | tee -a confluence-bootstrap.txt` if there are errors, feel free to reach out, otherwise if it completes without any errors then your instance should be updates with additional content
+  * this will generate, display, and append logs to the file confluence-bootstrap.txt to preserve the run history
 
-The command with use the `secrets.yaml` as a source of secrets to occassionally add to the page contents.
+The command with use the `secrets.yaml` as a source of secrets to occasionally add to the page contents.
 
 ## My confluence instance seems to be in a bad state and the container keeps crashing
 To fix this, first bring down all the containers:

--- a/confluence/bootstrap/cmd/main.go
+++ b/confluence/bootstrap/cmd/main.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	confluenceInstanceURL = "https://hashicorp-team-ydfxybh0.atlassian.net"
+	confluenceInstanceURL = "http://localhost:8090"
 
 	// Whether to generate pages across all spaces in the Confluence instance, instead of just the one hard-coded space below
 	useAllSpaces = false
 
 	// If useAllSpaces is true, the script can take hours if not days to complete for Confluence instances with many spaces
-	//  spaceKeyAfter provides a shortcut to start the script from spaces with keys alphabetically equal to or after
+	//  spaceKeyAfter provides a shortcut to start the script from spaces with keys alphabetically equal to or after it
 	spaceKeyAfter         = ""
 	maxUpdatePageAttempts = 3
 

--- a/confluence/bootstrap/go.mod
+++ b/confluence/bootstrap/go.mod
@@ -3,11 +3,9 @@ module github.com/hashicorp/vault-scanning-and-insights-cli-demo/confluence/boot
 go 1.21.0
 
 require (
+	github.com/brianvoe/gofakeit/v6 v6.23.2
 	github.com/hashicorp/go-retryablehttp v0.7.4
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require (
-	github.com/brianvoe/gofakeit/v6 v6.23.2 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-)
+require github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/confluence/bootstrap/go.mod
+++ b/confluence/bootstrap/go.mod
@@ -4,6 +4,7 @@ go 1.21.0
 
 require (
 	github.com/brianvoe/gofakeit/v6 v6.23.2
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.4
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/confluence/bootstrap/go.sum
+++ b/confluence/bootstrap/go.sum
@@ -1,6 +1,8 @@
 github.com/brianvoe/gofakeit/v6 v6.23.2 h1:lVde18uhad5wII/f5RMVFLtdQNE0HaGFuBUXmYKk8i8=
 github.com/brianvoe/gofakeit/v6 v6.23.2/go.mod h1:Ow6qC71xtwm79anlwKRlWZW6zVq9D2XHE4QSSMP/rU8=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=


### PR DESCRIPTION
## Description

- Update original Confluence bootstrap script to support a mode where pages are generated across all spaces in the Confluence instance
- Resolves # [VAULT-28572](https://hashicorp.atlassian.net/browse/VAULT-28572)

## How has this been tested?
- Running this script for Confluence Cloud instance `hashicorp-team-ydfxybh0`, validate it retries when encountering 409s (will be running for the next 48-72 hours against ~5.9k spaces)
