### PR TITLE
VAULT-18172: Part 2 - Port over the bulk GitHub App installation script to Vault Radar

### DIFF
--- a/bulk-install-app/README.md
+++ b/bulk-install-app/README.md
@@ -1,0 +1,22 @@
+# Vault Radar Bulk Installation Script for GitHub Checks App
+
+## Requirements
+- [python >= 3.6](https://www.python.org/downloads/)
+- [python package requests](https://pypi.org/project/requests/)
+- [python package python-dotenv](https://pypi.org/project/python-dotenv/)
+- [python package beautifulsoup4](https://pypi.org/project/beautifulsoup4/)
+## Bulk installing a GitHub Checks App across organizations
+1. Navigate to Vault Radar portal, and import the organizations that need to install the GitHub App 
+2. In `hashicorp-guides/vault-radar-demo/bulk-install-app`, generate an environment file `.env`, with the following variables set:
+   - `USERNAME` - the GitHub user's username
+   - `PASSWORD` - the GitHub user's password
+   - `DOMAIN` - the domain of the GitHub Enterprise Server 
+     (optional: only required for GitHub Enterprise Server)
+   - `MAX_ORGANIZATIONS` - maximum number of successful organization installations per run of script 
+     (optional: if not set, will install on all organizations)
+3. Run the script with the following command to install: `python3 -u main.py 2>&1 | tee -a bulk-install-app-results.txt`
+   Run the script with the following command to uninstall: `python3 -u main.py --uninstall 2>&1 | tee -a bulk-install-app-results.txt`
+   NOTE: Only organizations/users that the logged in GitHub user has permissions to install/uninstall on will be installed/uninstalled.
+   - If two-factor authentication is enabled, the script will request input for the one-time password.
+        
+When contacting support, please send over the `bulk-install-app-results.txt` file generated from step 3. 

--- a/bulk-install-app/README.md
+++ b/bulk-install-app/README.md
@@ -8,12 +8,14 @@
 ## Bulk installing a GitHub Checks App across organizations
 1. Navigate to Vault Radar portal, and import the organizations that need to install the GitHub App 
 2. In `hashicorp-guides/vault-radar-demo/bulk-install-app`, generate an environment file `.env`, with the following variables set:
-   - `USERNAME` - the GitHub user's username
-   - `PASSWORD` - the GitHub user's password
-   - `DOMAIN` - the domain of the GitHub Enterprise Server 
+   - `GITHUB_USERNAME` - the GitHub user's username
+   - `GITHUB_PASSWORD` - the GitHub user's password
+   - `GITHUB_DOMAIN` - the domain of the GitHub Enterprise Server 
      (optional: only required for GitHub Enterprise Server)
    - `MAX_ORGANIZATIONS` - maximum number of successful organization installations per run of script 
      (optional: if not set, will install on all organizations)
+   - `GITHUB_APP_NAME` - the name of the app
+     (optional: if not set, will default to `hashicorp-vault-radar-checks-app`)
 3. Run the script with the following command to install: `python3 -u main.py 2>&1 | tee -a bulk-install-app-results.txt`
    Run the script with the following command to uninstall: `python3 -u main.py --uninstall 2>&1 | tee -a bulk-install-app-results.txt`
    NOTE: Only organizations/users that the logged in GitHub user has permissions to install/uninstall on will be installed/uninstalled.

--- a/bulk-install-app/config.py
+++ b/bulk-install-app/config.py
@@ -1,0 +1,16 @@
+import os
+
+from dotenv import load_dotenv
+from urllib.parse import urlparse
+
+load_dotenv()
+
+DOMAIN = os.environ.get('DOMAIN') or 'github.com'
+GITHUB_APP_NAME = os.environ.get('GITHUB_APP_NAME') or 'hashicorp-vault-radar-checks-app'
+USERNAME = os.environ.get('USERNAME')
+PASSWORD = os.environ.get('PASSWORD')
+DEBUG = bool(int(os.environ.get('DEBUG'))) if os.environ.get('DEBUG') else False
+MAX_ORGANIZATIONS = int(os.environ.get('MAX_ORGANIZATIONS')) if os.environ.get('MAX_ORGANIZATIONS') else None
+
+DOMAIN = urlparse(DOMAIN if '//' in DOMAIN else f'//{DOMAIN}').netloc
+APPS_LOCATION = 'apps' if DOMAIN == 'github.com' else 'github-apps'

--- a/bulk-install-app/config.py
+++ b/bulk-install-app/config.py
@@ -5,10 +5,10 @@ from urllib.parse import urlparse
 
 load_dotenv()
 
-DOMAIN = os.environ.get('DOMAIN') or 'github.com'
+DOMAIN = os.environ.get('GITHUB_DOMAIN') or 'github.com'
 GITHUB_APP_NAME = os.environ.get('GITHUB_APP_NAME') or 'hashicorp-vault-radar-checks-app'
-USERNAME = os.environ.get('USERNAME')
-PASSWORD = os.environ.get('PASSWORD')
+USERNAME = os.environ.get('GITHUB_USERNAME')
+PASSWORD = os.environ.get('GITHUB_PASSWORD')
 DEBUG = bool(int(os.environ.get('DEBUG'))) if os.environ.get('DEBUG') else False
 MAX_ORGANIZATIONS = int(os.environ.get('MAX_ORGANIZATIONS')) if os.environ.get('MAX_ORGANIZATIONS') else None
 

--- a/bulk-install-app/debug.py
+++ b/bulk-install-app/debug.py
@@ -8,17 +8,17 @@ def save_debug_info(folder, name, response):
         if not os.path.exists(f"{folder}"):
             os.makedirs(f"{folder}")
 
-        file = open(f"{folder}/{name}-content.html", "w")
-        file.write(response.content.decode("utf-8"))
-        file.close()
+        with open(f"{folder}/{name}-content.html", "w") as file:
+            file.write(response.content.decode("utf-8"))
+            file.close()
 
-        file = open(f"{folder}/{name}-text.txt", "w")
-        file.write(response.text)
-        file.close()
+        with open(f"{folder}/{name}-text.txt", "w") as file:
+            file.write(response.text)
+            file.close()
 
-        file = open(f"{folder}/{name}-headers.txt", "w")
-        file.write(str(response.headers))
-        file.close()
+        with open(f"{folder}/{name}-headers.txt", "w") as file:
+            file.write(str(response.headers))
+            file.close()
 
 
 def translate_to_curl(response):

--- a/bulk-install-app/debug.py
+++ b/bulk-install-app/debug.py
@@ -1,0 +1,31 @@
+import os
+
+from config import DEBUG
+
+
+def save_debug_info(folder, name, response):
+    if DEBUG:
+        if not os.path.exists(f"{folder}"):
+            os.makedirs(f"{folder}")
+
+        file = open(f"{folder}/{name}-content.html", "w")
+        file.write(response.content.decode("utf-8"))
+        file.close()
+
+        file = open(f"{folder}/{name}-text.txt", "w")
+        file.write(response.text)
+        file.close()
+
+        file = open(f"{folder}/{name}-headers.txt", "w")
+        file.write(str(response.headers))
+        file.close()
+
+
+def translate_to_curl(response):
+    if DEBUG:
+        req = response.request
+        command = "curl -X {method} -H {headers} -d '{data}' '{uri}'"
+        method, uri, data = req.method, req.url, req.body
+        headers = ["'{0}: {1}'".format(k, v) for k, v in req.headers.items()]
+        headers = " -H ".join(headers)
+        print(f'cURL equivalent of request: {command.format(method=method, headers=headers, data=data, uri=uri)}')

--- a/bulk-install-app/install.py
+++ b/bulk-install-app/install.py
@@ -1,0 +1,166 @@
+import re
+import traceback
+from typing import Optional
+from urllib.parse import parse_qs, urlparse
+
+from bs4 import BeautifulSoup
+from config import APPS_LOCATION, DOMAIN, GITHUB_APP_NAME
+from debug import save_debug_info
+
+
+def start_install(session, target_name, target_id):
+    """
+    Start the installation process by pulling the install and authorize form.
+    Returns tuple of (authenticity_token, target_type, version_id, integration_fingerprint).
+
+    Will return None if current user does not have permissions to install.
+    """
+    url = f'https://{DOMAIN}/{APPS_LOCATION}/{GITHUB_APP_NAME}/installations/new/permissions?target_id={target_id}'
+
+    installation_response = session.get(url)
+    installation_page_soup = BeautifulSoup(installation_response.content, 'html.parser')
+    save_debug_info(folder='install-data', name='install', response=installation_response)
+
+    installation_button = installation_page_soup.find('button', {'data-octo-click': 'install_integration'})
+    if 'install' in installation_button.string.lower():
+        print(f'User has permissions to install on organization/user: {target_name}. Installing.')
+    elif 'request' in installation_button.string.lower():
+        print(f'User does not have owner permissions to install on organization/user: {target_name}. Skipping. ')
+        return
+    else:
+        print(f'Error parsing installation page and button for organization/user: {target_name}. Skipping. ')
+        return
+
+    installation_form = installation_page_soup.find('form', {'action': f'/{APPS_LOCATION}/{GITHUB_APP_NAME}/installations'})
+    authenticity_token = installation_form.find('input', {'name': 'authenticity_token'}).get('value')
+    target_type = installation_form.find('input', {'name': 'target_type'}).get('value')
+    version_id = installation_form.find('input', {'name': 'version_id'}).get('value')
+    integration_fingerprint = installation_form.find('input', {'name': 'integration_fingerprint'}).get('value')
+
+    return authenticity_token, target_type, version_id, integration_fingerprint
+
+
+def process_install(session, authenticity_token, target_id, target_type, version_id, integration_fingerprint):
+    """
+    Install the app on the target_id / target_type specified in input params.
+    """
+    url = f'https://{DOMAIN}/{APPS_LOCATION}/{GITHUB_APP_NAME}/installations'
+    installation_request_data = {
+        'authenticity_token': authenticity_token,
+        'target_id': target_id,
+        'target_type': target_type,
+        'version_id': version_id,
+        'integration_fingerprint': integration_fingerprint,
+        'install_target': 'all',
+    }
+
+    headers = {
+        'authority': f'{DOMAIN}',
+        'cache-control': 'max-age=0',
+        'sec-ch-ua': '"Google Chrome";v="89", "Chromium";v="89", ";Not A Brand";v="99"',
+        'sec-ch-ua-mobile': '?0',
+        'upgrade-insecure-requests': '1',
+        'origin': f'https://{DOMAIN}',
+        'content-type': 'application/x-www-form-urlencoded',
+        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36',  # noqa E501
+        'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',  # noqa E501
+        'sec-fetch-site': 'same-origin',
+        'sec-fetch-mode': 'navigate',
+        'sec-fetch-user': '?1',
+        'sec-fetch-dest': 'document',
+        'referer': f'{url}/new/permissions?target_id={target_id}',
+        'accept-language': 'en-US,en;q=0.9',
+    }
+
+    installed_response = session.post(url, installation_request_data, headers=headers)
+    save_debug_info(folder='install-data', name='installed', response=installed_response)
+
+    return installed_response
+
+
+def check_install_result(installed_response) -> bool:
+    """
+    Handle the redirect to the app's callback URL.
+    Returns a boolean for whether the installation succeeded.
+    """
+    save_debug_info(folder='install-data', name='check', response=installed_response)
+    return 'was installed on' in installed_response.text.lower()
+
+
+def install(session, target_name, target_url) -> Optional[bool]:
+    """
+    Manages full installation workflow - start, process, redirect.
+
+    Returns boolean for whether installation has occurred without any errors.
+    Returns None if user did not have permissions to install, or if errors occurred in pre-installation parsing.
+    """
+    try:
+        target_id = parse_qs(urlparse(target_url).query)['target_id'][0]
+
+        installation_data = start_install(session=session, target_name=target_name, target_id=target_id)
+        if installation_data:
+            authenticity_token, target_type, version_id, integration_fingerprint = installation_data
+            installed_response = process_install(
+                session=session,
+                authenticity_token=authenticity_token,
+                target_id=target_id,
+                target_type=target_type,
+                version_id=version_id,
+                integration_fingerprint=integration_fingerprint,
+            )
+
+            success = check_install_result(installed_response=installed_response)
+            return success
+        return None
+    except Exception:
+        traceback.print_exc()
+        return False
+
+
+def check_uninstall_result(uninstall_complete_page):
+    """
+    Given the resulting uninstall page, check to see if uninstall succeeded.
+    """
+    return 'has been uninstalled' in uninstall_complete_page.text
+
+
+def uninstall(session, target_name: str, target_id: Optional[int] = None, target_url: Optional[str] = None):
+    """
+    Manages full uninstallation workflow - start, complete.
+    Returns boolean for whether uninstall succeeded.
+    """
+    if not target_id and not target_url:
+        print(f'Neither target_id nor target_url was passed in, cannot uninstall organization/user: {target_name}.')
+        return False
+
+    try:
+        if target_id:
+            url = f'https://{DOMAIN}/{APPS_LOCATION}/{GITHUB_APP_NAME}/installations/new/permissions?target_id={target_id}'
+        else:
+            url = f'https://{DOMAIN}{target_url}'
+
+        uninstall_start_response = session.get(url)
+        save_debug_info(folder='uninstall-data', name=f'uninstall-{target_name}-start', response=uninstall_start_response)
+
+        uninstallation_page_soup = BeautifulSoup(uninstall_start_response.content, 'html.parser')
+        uninstallation_form = uninstallation_page_soup.find(
+            'form', {'action': re.compile('/settings/installations/[0-9]*$')}
+        )
+
+        if not uninstallation_form:
+            print(f'User does not have owner permissions to uninstall on organization/user: {target_name}. Skipping.')
+            return
+
+        authenticity_token = uninstallation_form.find('input', {'name': 'authenticity_token'}).get('value')
+        uninstallation_action = uninstallation_form.get('action')
+
+        uninstall_data = {'authenticity_token': authenticity_token, '_method': 'delete'}
+        uninstall_complete_response = session.post(f'https://{DOMAIN}{uninstallation_action}', uninstall_data)
+        save_debug_info(
+            folder='uninstall-data', name=f'uninstall-{target_name}-complete', response=uninstall_complete_response
+        )
+        uninstall_complete_page = BeautifulSoup(uninstall_complete_response.content, 'html.parser')
+        return check_uninstall_result(uninstall_complete_page)
+    except Exception:
+        traceback.print_exc()
+        return False

--- a/bulk-install-app/login.py
+++ b/bulk-install-app/login.py
@@ -1,0 +1,107 @@
+import re
+import traceback
+
+from bs4 import BeautifulSoup
+from config import DOMAIN, PASSWORD, USERNAME
+from debug import save_debug_info
+
+
+def start_login(session):
+    """
+    Start the login process by pulling the login form.
+    """
+    login_response = session.get(f'https://{DOMAIN}/login')
+    login_page_soup = BeautifulSoup(login_response.content, 'html.parser')
+    save_debug_info(folder='login-data', name='login-start', response=login_response)
+
+    login_form = login_page_soup.find('form', {'action': '/session'})
+    return login_form
+
+
+def complete_login(session, login_form):
+    """
+    Complete the login process by pulling the authenticity token from the login form,
+    and sending username/password.
+    """
+    authenticity_token = login_form.find('input', {'name': 'authenticity_token'}).get('value')
+    login_request_data = {
+        'commit': 'Sign in',
+        'authenticity_token': authenticity_token,
+        'login': USERNAME,
+        'password': PASSWORD,
+        'trusted_device': '',
+        'webauthn-support': 'supported',
+        'webauthn-iuvpaa-support': 'supported',
+        'return_to': '',
+        'allow_signup': '',
+        'client_id': '',
+        'integration': '',
+        'required_field_e106': '',
+    }
+
+    login_response = session.post(f'https://{DOMAIN}/session', login_request_data)
+    login_page_soup = BeautifulSoup(login_response.content, 'html.parser')
+    save_debug_info(folder='login-data', name='login-complete', response=login_response)
+
+    return login_page_soup
+
+
+def check_login_success(login_page_main):
+    """
+    Given the resulting login page, check to see if login succeeded.
+    """
+    login_page_header = login_page_main.find('h1')
+    return 'sign in to your account' not in login_page_header.string.lower()
+
+
+def check_tfa_success(tfa_login_page):
+    """
+    Given the resulting two-factor login page, check to see if two-factor succeeded.
+    """
+    tfa_login_page_auth = tfa_login_page.find('div', {'class': re.compile('auth-form-header*', re.IGNORECASE)})
+    if not tfa_login_page_auth:
+        return True
+
+    tfa_login_page_header = tfa_login_page_auth.find('h1')
+    return 'two-factor' not in tfa_login_page_header.string.lower()
+
+
+def handle_tfa(session, login_page):
+    """
+    Check if two factor is necessary, and handle if necessary.
+    Return boolean for whether two-factor step has succeeded (should return True if two-factor is unnecessary).
+    """
+    tfa_unnecessary = check_tfa_success(tfa_login_page=login_page)
+    if tfa_unnecessary:
+        print('Two-factor authentication not required.')
+        return True
+
+    otp = input('Two-factor authentication required, input here: ')
+
+    two_factor_form = login_page.find('form', {'action': {'/sessions/two-factor'}})
+    authenticity_token = two_factor_form.find('input', {'name': 'authenticity_token'}).get('value')
+    two_factor_data = {'authenticity_token': authenticity_token, 'otp': otp}
+    tfa_response = session.post('https://github.com/sessions/two-factor', two_factor_data)
+    save_debug_info(folder='login-data', name='tfa', response=tfa_response)
+
+    tfa_login_page = BeautifulSoup(tfa_response.content, 'html.parser')
+
+    return check_tfa_success(tfa_login_page=tfa_login_page)
+
+
+def setup_login(session):
+    try:
+        login_form = start_login(session=session)
+        login_page = complete_login(session=session, login_form=login_form)
+        login_page_main = login_page.find('div', {'class': 'application-main'})
+
+        login_success = check_login_success(login_page_main=login_page_main)
+        login_success = login_success and handle_tfa(session=session, login_page=login_page)
+    except Exception:
+        traceback.print_exc()
+        login_success = False
+
+    if login_success:
+        print(f'Succeeded to login for GitHub user: {USERNAME} \n')
+        return
+    print(f'Failed to login for GitHub user: {USERNAME} \n')

--- a/bulk-install-app/main.py
+++ b/bulk-install-app/main.py
@@ -1,0 +1,59 @@
+import argparse
+import asyncio
+from datetime import datetime
+
+import requests
+from config import DOMAIN, GITHUB_APP_NAME, MAX_ORGANIZATIONS
+from install import uninstall, install
+from login import setup_login
+from organization import organizations
+
+
+if __name__ == '__main__':
+    session = requests.Session()
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-u', '--uninstall', action='store_true', default=False)
+    args = parser.parse_args()
+    action = 'Uninstall' if args.uninstall else 'Install'
+
+    print('\n')
+    print(f'{datetime.now()} - Bulk {action}')
+    print(f'GitHub App: {GITHUB_APP_NAME}, Domain: {DOMAIN}, Max Organizations: {MAX_ORGANIZATIONS}')
+    print('\n')
+
+    # Handle logging in
+    setup_login(session=session)
+
+    # Get all organizations
+    success_counter = 0
+    for organization_tuple in organizations(session, uninstall=args.uninstall):
+        # Handle installation for one organization
+        target_name, target_url = organization_tuple
+        action = 'install' if not args.uninstall else 'uninstall'
+        print(f'Found organization/user: {target_name}, to {action} app: {GITHUB_APP_NAME}.')
+
+        if not args.uninstall:
+            # Marking installation success
+            success = install(session=session, target_name=target_name, target_url=target_url)
+        else:
+            # Marking uninstallation success
+            success = uninstall(session=session, target_name=target_name, target_url=target_url)
+
+        if success:
+            print(f'Succeeded {action}ation for GitHub organization/user: {target_name}\n')
+        elif success is False:
+            print(f'Failed {action}ation for GitHub organization/user: {target_name}\n')
+        else:
+            print(f'Skipped {action}ation for GitHub organization/user: {target_name}\n')
+
+        # Stop early if succeeded on max installations/uninstallations
+        success_counter += int(bool(success))
+        if MAX_ORGANIZATIONS and success_counter == MAX_ORGANIZATIONS:
+            print(f'Hit max organizations: {MAX_ORGANIZATIONS}, finishing. ')
+            break
+
+        # Sleep briefly between installations
+        delay = 2
+        asyncio.run(asyncio.sleep(delay))
+    print('\n')

--- a/bulk-install-app/organization.py
+++ b/bulk-install-app/organization.py
@@ -1,0 +1,72 @@
+import re
+
+from bs4 import BeautifulSoup
+from config import APPS_LOCATION, DOMAIN, GITHUB_APP_NAME
+from debug import save_debug_info
+
+
+def organizations_by_page(session):
+    """
+    Returns a generator of organizations/users to install the app on, by page.
+    """
+    url = f'https://{DOMAIN}/{APPS_LOCATION}/{GITHUB_APP_NAME}/installations/select_target'
+    app_install_response = session.get(url)
+    save_debug_info(folder='organization-data', name='page-1', response=app_install_response)
+    app_install_page_soup = BeautifulSoup(app_install_response.content, 'html.parser')
+    app_install_page_main = app_install_page_soup.find('div', {'class': 'application-main'})
+    yield app_install_page_main
+
+    current_elem = app_install_page_soup.find('em', {'class': 'current'})
+    if current_elem:
+        total_pages = current_elem.get('data-total-pages')
+        for page_number in range(2, int(total_pages) + 1):
+            app_install_response = session.get(f'{url}?page={page_number}')
+            save_debug_info(folder='organization-data', name=f'page-{page_number}', response=app_install_response)
+            app_install_page_soup = BeautifulSoup(app_install_response.content, 'html.parser')
+            app_install_page_main = app_install_page_soup.find('div', {'class': 'application-main'})
+            yield app_install_page_main
+
+
+def organizations_to_install_on_by_item(app_install_page_soup):
+    """
+    Given a page of organizations/users to install the app on, returns a generator by item.
+    Filters out organizations/users that have already installed the app.
+    """
+    for row in app_install_page_soup.find_all('a', {'class': re.compile('Box-row*', re.IGNORECASE)}):
+        target_name = row.find('img').get('alt').lstrip('@')
+        target_url = row.get('href')
+
+        label = row.find('span').get('aria-label')
+        if label and 'is installed' in label.lower():
+            print(f'Organization/user: {target_name} has already installed app: {GITHUB_APP_NAME}. Skipping. \n')
+            continue
+        yield target_name, target_url
+
+
+def organizations_to_uninstall_on_by_item(app_install_page_soup):
+    """
+    Given a page of organizations/users to uninstall the app on, returns a generator by item.
+    Filters out organizations/users that haven't yet installed the app.
+    """
+    for row in app_install_page_soup.find_all('a', {'class': re.compile('Box-row*', re.IGNORECASE)}):
+        target_name = row.find('img').get('alt').lstrip('@')
+        target_url = row.get('href')
+
+        label = row.find('span').get('aria-label')
+        if not label or 'is installed' not in label.lower():
+            print(f'Organization/user: {target_name} has not yet installed app: {GITHUB_APP_NAME}. Skipping. \n')
+            continue
+        yield target_name, target_url
+
+
+def organizations(session, uninstall: bool):
+    """
+    Returns a generator of organizations to install on.
+    """
+    organizations_by_item_generator = (
+        organizations_to_uninstall_on_by_item if uninstall else organizations_to_install_on_by_item
+    )
+
+    for app_install_page_soup in organizations_by_page(session=session):
+        for organization_tuple in organizations_by_item_generator(app_install_page_soup=app_install_page_soup):
+            yield organization_tuple


### PR DESCRIPTION
## Description
- Tested against GitHub Enterprise Server 3.13.3
- Validated bulk installation (with pagination) and bulk uninstallation (with pagination) work
- Validated edge cases when user doesn't have permission to install and when user doesn't have permission to uninstall
- Validated basic login against GitHub Enterprise Server works
- Did not validate 2FA, did not implement SSO
- Did not validate GitHub Cloud

Resolves # [VAULT-18172](https://hashicorp.atlassian.net/browse/VAULT-18172)

## How has this been tested?
- Have independently run the two commands below to completion on a GitHub Enterprise Server instance at version 3.13.3 
```
python3 -u main.py 2>&1 | tee -a bulk-install-app-results.txt
python3 -u main.py --uninstall 2>&1 | tee -a bulk-install-app-results.txt
```

